### PR TITLE
Measure time-taken in nREPL middleware

### DIFF
--- a/package.py
+++ b/package.py
@@ -31,7 +31,6 @@ class Eval:
         self.msg = None
         self.trace = None
         self.phantom_id = None
-        self.start_time = None
         Eval.next_id += 1
         self.update("pending", None, region)
 
@@ -65,11 +64,9 @@ class Eval:
             scope, color = self.scope_color()
             if value:
                 threshold = settings().get("elapsed_threshold_ms")
-                if threshold != None and self.start_time and self.status in {"success", "exception"}:
-                    elapsed = time.perf_counter() - self.start_time
+                if threshold != None and time_taken != None and self.status in {"success", "exception"}:
+                    elapsed = time_taken / 1000000000
                     if elapsed * 1000 >= threshold:
-                        if time_taken is not None:
-                            elapsed = time_taken / 1000000000
                         if elapsed >= 10:
                             value = f"({'{:,.0f}'.format(elapsed)} sec) {value}"
                         elif elapsed >= 1:
@@ -115,7 +112,6 @@ class StatusEval(Eval):
         self.session = None
         self.msg = None
         self.trace = None
-        self.start_time = None
         Eval.next_id += 1
         self.update("pending", None)
 
@@ -220,7 +216,6 @@ def handle_new_session(msg):
         eval = conn.evals[msg["id"]]
         eval.session = msg["new-session"]
         eval.msg["session"] = msg["new-session"]
-        eval.start_time = time.perf_counter()
         conn.send(eval.msg)
         eval.update("pending", progress_thread.phase())
         return True

--- a/package.py
+++ b/package.py
@@ -593,7 +593,8 @@ def handle_connect(msg):
 
     elif 2 == msg.get("id") and msg.get("status") == ["done"]:
         conn.send({"op":               "add-middleware",
-                   "middleware":       [f"{ns}.middleware/wrap-errors",
+                   "middleware":       [f"{ns}.middleware/time-eval",
+                                        f"{ns}.middleware/wrap-errors",
                                         f"{ns}.middleware/wrap-output"],
                    "extra-namespaces": [f"{ns}.middleware"],
                    "session":          conn.session,


### PR DESCRIPTION
Closes #13.

Still over-reports times by ~1ms, presumably because of default middleware.

One approach to make this better, could be by calling `ls-middleware` and `swap-middleware` to insert the timing middleware at the bottom of the stack. WDYT?

Also, there seem to be calls to `update` with value but without `time_taken`. In such cases, I'm falling back to client-measured time. What am I missing?